### PR TITLE
Remove unnecessary call to decodeURIComponent when executing command.

### DIFF
--- a/app/scripts/models/command.coffee
+++ b/app/scripts/models/command.coffee
@@ -23,6 +23,5 @@ define [
     execute: ->
       Extension.trigger "fetch.commands", @attributes
       App.once "fetched.commands", (src) =>
-        src = decodeURIComponent src
         window.location = "javascript:#{encodeURIComponent src}"
         App.trigger "close"


### PR DESCRIPTION
Without this, a command.js containing any percent sign (%) would cause
the backtick extension to crash.  

For example, install the `command-with-percent-sign` command from here: https://gist.github.com/dergachev/9ccc58335d01e6f62b7b

Activating it on any page will crash backtick, with the following message written to the console:

```
Error in event handler for runtime.onMessage: URIError: URI malformed
```

This is because decodeURIComponent (which backtick runs on the JS source) chokes line was added in commit, but it's certainly not necessary for commands loaded with gists. For context, see
this commit:
https://github.com/JoelBesada/Backtick/commit/3e773c9d3b221f63f2f8d9d0e595e42dc23aadb7

Note that this PR has only been tested as far as it makes my [HTML Outline bookmarklet](https://gist.github.com/dergachev/7792914) work. I haven't yet even figured
out how to get the tests to run.
